### PR TITLE
Change the parameter name for identifying the movies in the carousel

### DIFF
--- a/src/components/carousel/carousel.jsx
+++ b/src/components/carousel/carousel.jsx
@@ -106,10 +106,10 @@ function Carousel() {
             >
                 {movies.map((movie) => (
                     <div
-                        key={movie.id}
+                        key={movie.slug + "wrapper"}
                         className="shrink-0 w-[calc(100%-0.5rem)] sm:w-[calc(50%-0.5rem)] md:w-[calc(33.333%-0.67rem)] lg:w-[calc(25%-0.75rem)] xl:w-[calc(20%-0.8rem)]"
                     >
-                        <MovieCard movie={movie} />
+                        <MovieCard key={movie.slug} movie={movie} />
                     </div>
                 ))}
             </div>


### PR DESCRIPTION
Problem with repeating key solved, by changing the movie.id to movie.slug (the latter is defined)